### PR TITLE
Fix Seed RNG Bug

### DIFF
--- a/Assets/Canvases/MainMenu.cs
+++ b/Assets/Canvases/MainMenu.cs
@@ -6,13 +6,17 @@ using UnityEngine.UI;
 public class MainMenu : MonoBehaviour
 {
     [SerializeField]
-    TextMeshProUGUI inputText;
+    TMP_InputField inputField;
 
     const string GAME_SCENE_STRING = "GameScene";
 
     public void OnButtonPressed()
     {
-        if (int.TryParse(inputText.text, out int gameSeed))
+        Debug.Log("Button pressed. Input text value: " + inputField.text);
+
+        Debug.Log($"Can this be parsed to an integer? {int.TryParse(inputField.text, out int i)}");
+
+        if (int.TryParse(inputField.text, out int gameSeed))
         {
             RNGSeedManager.Instance.SetGameSeed(gameSeed);
         }

--- a/Assets/Map Generation/Scripts/RNGSeedManager.cs
+++ b/Assets/Map Generation/Scripts/RNGSeedManager.cs
@@ -24,12 +24,15 @@ public class RNGSeedManager : MonoBehaviour
     public void SetGameSeed(int newGameSeed)
     {
         gameSeed = newGameSeed;
+
+        Debug.Log("Game seed: " + gameSeed);
+
         UnityEngine.Random.InitState(gameSeed);
     }
 
     public void SetGameSeedRandom()
     {
-        gameSeed = Random.Range(0, int.MaxValue);
-        UnityEngine.Random.InitState(gameSeed);
+        SetGameSeed(Random.Range(0, int.MaxValue));
+
     }
 }


### PR DESCRIPTION
This commit fixes the RNG bug, where the player would input the seed & the map would come out differently.

The problem: I referenced the textmeshprougui component where the player was inputting their game seed. the issue with this is the component value was stored statically, so the player input text was always "", which is not an integer (causing the seed to be set to a random number).

The Solution: Change the reference to the input field component, not the textmeshprougui. Get its text value and that will return the player's input. For future reference, textmeshprougui's value is read statically, not dynamically. changing its value does not change reference values. Be cautious in the future doing this.