### PR TITLE
Misc changes

### DIFF
--- a/Assets/Editor.meta
+++ b/Assets/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ca2074ac053930743be2ab7e4fa2ecd3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/PlayFromInitScene.cs
+++ b/Assets/Editor/PlayFromInitScene.cs
@@ -1,0 +1,100 @@
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+//Pure ChatGPT code w/ some modifications. I will break down what is happening logically through the script.
+
+[InitializeOnLoad]
+public static class PlayFromInitScene
+{
+    //Store the path to the initialization scene (Assets/Scenes/initSceneName.unity)
+    private const string InitScenePath = "Assets/Scenes/Initialization.unity";
+
+    //Create session keys for the current scene. Basically, these are strings to act as variables in the SessionState class
+    //Session keys act like Editor-persistent variables that survive domain reloads
+    private const string SessionKeyPrevScene = "PlayFromInitScene.prevScene";
+
+    //1/0 variable to determine whether the scene did switch. 1 if true, 0 if false
+    private const string SessionKeyDidSwitch = "PlayFromInitScene.didSwitch";
+
+    //Runs when the Unity editor reloads
+    static PlayFromInitScene()
+    {
+        //Handle logic for when the play mode state changes. (i.e., entering/exiting edit/play mode)
+        EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+    }
+
+    private static void OnPlayModeStateChanged(PlayModeStateChange state)
+    {
+        //Handle logic for exiting edit mode (entering play mode)
+        if (state == PlayModeStateChange.ExitingEditMode)
+        {
+            //If init scene doesn't exist, cancel and warn
+            if (!System.IO.File.Exists(InitScenePath))
+            {
+                Debug.LogError($"PlayFromInitScene: Init scene not found at '{InitScenePath}'. Cancelling play.");
+                EditorApplication.isPlaying = false;
+                return;
+            }
+
+            //Store the current scene
+            var current = EditorSceneManager.GetActiveScene();
+
+            // If we're already on the init scene, do nothing (don't overwrite stored path)
+            if (current.path == InitScenePath)
+            {
+                SessionState.SetInt(SessionKeyDidSwitch, 0);
+                SessionState.SetString(SessionKeyPrevScene, "");
+                return;
+            }
+
+            // Ask the user to save modified scenes. If they cancel, cancel play.
+            if (!EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo())
+            {
+                EditorApplication.isPlaying = false;
+                return;
+            }
+
+            // store the current scene path in SessionState so it survives domain reload
+            SessionState.SetString(SessionKeyPrevScene, current.path);
+            SessionState.SetInt(SessionKeyDidSwitch, 1);
+
+            //Store the scene name for init obj to reference
+            PlayerPrefs.SetString("PlayFromInitScene.PreviousScene", current.name);
+            PlayerPrefs.Save();
+
+            // open the init scene (single mode so it becomes the active scene)
+            EditorSceneManager.OpenScene(InitScenePath, OpenSceneMode.Single);
+        }
+
+        //Handle logic for returning to edit mode
+        else if (state == PlayModeStateChange.EnteredEditMode)
+        {
+            //Determine if the scene did switch
+            if (SessionState.GetInt(SessionKeyDidSwitch, 0) != 1)
+            {
+                // we didn't switch earlier, nothing to restore
+                return;
+            }
+
+            //Store the previous scene path from session state
+            var prev = SessionState.GetString(SessionKeyPrevScene, "");
+
+            //Check if the scene can be opened
+            if (!string.IsNullOrEmpty(prev) && prev != InitScenePath && System.IO.File.Exists(prev))
+            {
+                //Open the scene
+                EditorSceneManager.OpenScene(prev, OpenSceneMode.Single);
+            }
+            else
+            {
+                // nothing to restore (either lost path or previous scene was removed)
+                Debug.Log("PlayFromInitScene: No previous scene to restore (it may have been removed or was the init scene).");
+            }
+
+            //cleanup session state
+            SessionState.SetInt(SessionKeyDidSwitch, 0);
+            SessionState.SetString(SessionKeyPrevScene, "");
+        }
+    }
+}

--- a/Assets/Editor/PlayFromInitScene.cs.meta
+++ b/Assets/Editor/PlayFromInitScene.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4c47cfeff1559e14b96b2a5e733925f1

--- a/Assets/Initialization.meta
+++ b/Assets/Initialization.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a19a6f846e19b8e478ff447afc01f824
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Initialization/InitObj.prefab
+++ b/Assets/Initialization/InitObj.prefab
@@ -1,0 +1,49 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8509441460001954737
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7324245354653260495}
+  - component: {fileID: 8785308623790758778}
+  m_Layer: 0
+  m_Name: InitObj
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7324245354653260495
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8509441460001954737}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8785308623790758778
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8509441460001954737}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7278e353db21f9542bcd3630313c5f4d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::InitializeGame
+  singletonManagersAndObject:
+  - {fileID: 3386012716937548043, guid: b6b56c3fa21396a4b8c5c483e11a30c6, type: 3}
+  - {fileID: 1167604989491927238, guid: 8a21dbe6c6494134b8490d9a17ae4490, type: 3}

--- a/Assets/Initialization/InitObj.prefab.meta
+++ b/Assets/Initialization/InitObj.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 38e9e4d34de066d41941fe05b03f1bb7
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Initialization/InitializeGame.cs
+++ b/Assets/Initialization/InitializeGame.cs
@@ -1,0 +1,45 @@
+using Unity.VisualScripting;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class InitializeGame : MonoBehaviour
+{
+    [SerializeField]
+    GameObject[] singletonManagersAndObject;
+
+    string sceneToLoad = string.Empty;
+
+    const string MAIN_MENU_SCENE = "MainMenu";
+
+    private void Awake()
+    {
+        //Create all given singletons
+        foreach (GameObject singleton in singletonManagersAndObject)
+        {
+            //craete the singleton
+            GameObject newSingleton = Instantiate(singleton);
+            newSingleton.name = singleton.name;
+        }
+
+        //Check if there is a specific scene to reload
+        sceneToLoad = PlayerPrefs.GetString("PlayFromInitScene.PreviousScene", "");
+
+        //Delele the entry if it existed
+        PlayerPrefs.DeleteKey("PlayFromInitScene.PreviousScene");
+    }
+
+    private void Start()
+    {
+        //Load next scene behavior
+        if (!string.IsNullOrEmpty(sceneToLoad))
+        {
+            // Load the previous scene
+            SceneManager.LoadScene(sceneToLoad);
+        }
+        else
+        {
+            // Fallback: load main menu
+            SceneManager.LoadScene(MAIN_MENU_SCENE);
+        }
+    }
+}

--- a/Assets/Initialization/InitializeGame.cs.meta
+++ b/Assets/Initialization/InitializeGame.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7278e353db21f9542bcd3630313c5f4d

--- a/Assets/Map Generation/Scripts/RNGSeedManager.cs
+++ b/Assets/Map Generation/Scripts/RNGSeedManager.cs
@@ -12,6 +12,7 @@ public class RNGSeedManager : MonoBehaviour
         if (Instance == null)
         {
             Instance = this;
+            DontDestroyOnLoad(gameObject);
         }
         else
         {

--- a/Assets/Player/Input_Action_Map/InputManager.cs
+++ b/Assets/Player/Input_Action_Map/InputManager.cs
@@ -1,16 +1,39 @@
+using System;
+using System.Linq;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class InputManager : MonoBehaviour
 {
+    public enum InputControlScheme
+    {
+        Player,
+        UI
+    }
+
+    [System.Serializable]
+    public class SceneControlBinding
+    {
+        public SceneReferenceSO scene;
+        public InputControlScheme inputControlScheme;
+    }
+
+
+    [SerializeField, Tooltip("Stores reference to scenes to handle their initial logic for loading into the scene. For example, " +
+        "loading into the main menu should enable UI control scheme, and loading into the game scene should enable play control scheme")]
+    SceneControlBinding[] scenesInBuildIndex;
+
+
     //Singleton
     public static InputManager Instance;
 
     //Player controls
     Controls controls;
 
+    bool initialized = false;
+
     private void Awake()
     {
-
         //Singleton Pattern
         if (Instance == null)
         {
@@ -25,10 +48,12 @@ public class InputManager : MonoBehaviour
 
         //Craete player controls
         controls = new Controls();
+
+        initialized = true;
+
         //Set controls to default
         EnableDefaultControls();
     }
-
 
     //Input debugging
     /*
@@ -62,10 +87,70 @@ public class InputManager : MonoBehaviour
 
     */
 
-    private void OnDestroy()
+    private void OnEnable()
     {
+        SceneManager.sceneLoaded += HandleSceneLoaded;
+    }
+
+    private void OnDisable()
+    {
+        if (!initialized) { return; }
+
         controls.Player.Disable();
         controls.UI.Disable();
+        SceneManager.sceneLoaded -= HandleSceneLoaded;
+    }
+
+    private void OnDestroy()
+    {
+        if (!initialized) { return; }
+
+        controls.Player.Disable();
+        controls.UI.Disable();
+        SceneManager.sceneLoaded -= HandleSceneLoaded;
+
+        controls.Dispose();
+    }
+
+    //Subscription events
+    private void HandleSceneLoaded(Scene newScene, LoadSceneMode arg1)
+    {
+        bool controlSchemeApplied = false;
+
+        //Check if the scene has a certain control scheme to initialize as
+        foreach (SceneControlBinding sceneControlBinding in scenesInBuildIndex)
+        {
+            //Get the scene name
+            string sceneName = sceneControlBinding.scene.SceneName;
+
+            //Check if the scene name is the same as the new scene's name
+            if (newScene.name.CompareTo(sceneName) != 0) continue;
+
+            //Control scheme will be applied
+            controlSchemeApplied = true;
+
+            //Enable the corresponing input scheme based on the scene's control binding
+            switch (sceneControlBinding.inputControlScheme)
+            {
+                case InputControlScheme.Player:
+                    SetControlSchemeToPlayer();
+                    break;
+                case InputControlScheme.UI:
+                    SetControlSchemeToUI(); 
+                    break;
+                default:
+                    EnableDefaultControls();
+                    break;
+            }
+        }
+
+        //Check if the control scheme was applied
+        if (!controlSchemeApplied)
+        {
+            //Apply default controls on scene load
+            Debug.LogWarning($"Warning: No control scheme given for scene, '{newScene.name}'");
+            EnableDefaultControls();
+        }
     }
 
 
@@ -77,12 +162,20 @@ public class InputManager : MonoBehaviour
 
     public void SetControlSchemeToUI()
     {
+        //When the player is in the UI menus, they should see their mouse (or the mouse sprite if we add one) and their mouse position must be unlocked
+        Cursor.lockState = CursorLockMode.None;
+        Cursor.visible = true;
+
         controls.Player.Disable();
         controls.UI.Enable();
     }
 
     public void SetControlSchemeToPlayer()
     {
+        //When the player is playing the game, they should not see their mouse, and the mouse position must be locked in place.
+        Cursor.lockState = CursorLockMode.Locked;
+        Cursor.visible = false;
+
         controls.Player.Enable();
         controls.UI.Disable();
     }

--- a/Assets/Player/Input_Action_Map/InputManager.prefab
+++ b/Assets/Player/Input_Action_Map/InputManager.prefab
@@ -44,3 +44,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0bc6ec01ad2ca4a49817bbe901f1fde8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::InputManager
+  scenesInBuildIndex:
+  - scene: {fileID: 11400000, guid: ecec8295c9ea5fc459cadf337e1facd0, type: 2}
+    inputControlScheme: 1
+  - scene: {fileID: 11400000, guid: 58620c56919fc844295f14c916bd89ff, type: 2}
+    inputControlScheme: 1
+  - scene: {fileID: 11400000, guid: 3656f95c594475f478b5c2d62995b6d8, type: 2}
+    inputControlScheme: 0
+  - scene: {fileID: 11400000, guid: b5c6188e91c59c540b0717cc7f534855, type: 2}
+    inputControlScheme: 0
+  - scene: {fileID: 11400000, guid: ccae4967bd88d3f4eb8395ec8a0bb136, type: 2}
+    inputControlScheme: 0
+  - scene: {fileID: 11400000, guid: 579b7cf9857b731478cb3012249289ad, type: 2}
+    inputControlScheme: 0

--- a/Assets/Player/Input_Action_Map/InputManager.prefab
+++ b/Assets/Player/Input_Action_Map/InputManager.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1167604989491927238
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7072706191849307978}
+  - component: {fileID: 3761382246959056529}
+  m_Layer: 0
+  m_Name: InputManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7072706191849307978
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1167604989491927238}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3761382246959056529
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1167604989491927238}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0bc6ec01ad2ca4a49817bbe901f1fde8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::InputManager

--- a/Assets/Player/Input_Action_Map/InputManager.prefab.meta
+++ b/Assets/Player/Input_Action_Map/InputManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8a21dbe6c6494134b8490d9a17ae4490
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Initialization.unity
+++ b/Assets/Scenes/Initialization.unity
@@ -1,0 +1,799 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &589917763
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 589917766}
+  - component: {fileID: 589917765}
+  - component: {fileID: 589917764}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &589917764
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 589917763}
+  m_Enabled: 1
+--- !u!20 &589917765
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 589917763}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &589917766
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 589917763}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &682120670
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 682120671}
+  - component: {fileID: 682120673}
+  - component: {fileID: 682120672}
+  m_Layer: 5
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &682120671
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 682120670}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1232688208}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &682120672
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 682120670}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &682120673
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 682120670}
+  m_CullTransparentMesh: 1
+--- !u!1 &1196835574
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1196835577}
+  - component: {fileID: 1196835576}
+  - component: {fileID: 1196835575}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1196835575
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1196835574}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.InputSystem::UnityEngine.InputSystem.UI.InputSystemUIInputModule
+  m_SendPointerHoverToParent: 1
+  m_MoveRepeatDelay: 0.5
+  m_MoveRepeatRate: 0.1
+  m_XRTrackingOrigin: {fileID: 0}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_PointAction: {fileID: -1654692200621890270, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MoveAction: {fileID: -8784545083839296357, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_SubmitAction: {fileID: 392368643174621059, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_CancelAction: {fileID: 7727032971491509709, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_LeftClickAction: {fileID: 3001919216989983466, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MiddleClickAction: {fileID: -2185481485913320682, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_RightClickAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_DeselectOnBackgroundClick: 1
+  m_PointerBehavior: 0
+  m_CursorLockBehavior: 0
+  m_ScrollDeltaPerTick: 6
+--- !u!114 &1196835576
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1196835574}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.EventSystems.EventSystem
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &1196835577
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1196835574}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1232688204
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1232688208}
+  - component: {fileID: 1232688207}
+  - component: {fileID: 1232688206}
+  - component: {fileID: 1232688205}
+  m_Layer: 5
+  m_Name: InitializationCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1232688205
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1232688204}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.GraphicRaycaster
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1232688206
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1232688204}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.CanvasScaler
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &1232688207
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1232688204}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &1232688208
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1232688204}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 682120671}
+  - {fileID: 1809098587}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!1 &1809098586
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1809098587}
+  - component: {fileID: 1809098589}
+  - component: {fileID: 1809098588}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1809098587
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1809098586}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1232688208}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1809098588
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1809098586}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Initializing...
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 72
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1809098589
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1809098586}
+  m_CullTransparentMesh: 1
+--- !u!1 &2069096355
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2069096357}
+  - component: {fileID: 2069096356}
+  - component: {fileID: 2069096358}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &2069096356
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2069096355}
+  m_Enabled: 1
+  serializedVersion: 11
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ForceVisible: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+  m_LightUnit: 1
+  m_LuxAtDistance: 1
+  m_EnableSpotReflector: 1
+--- !u!4 &2069096357
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2069096355}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!114 &2069096358
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2069096355}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.RenderPipelines.Universal.Runtime::UnityEngine.Rendering.Universal.UniversalAdditionalLightData
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_CustomShadowLayers: 0
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
+  m_RenderingLayersMask:
+    serializedVersion: 0
+    m_Bits: 1
+  m_ShadowRenderingLayersMask:
+    serializedVersion: 0
+    m_Bits: 1
+  m_Version: 4
+  m_LightLayerMask: 1
+  m_ShadowLayerMask: 1
+  m_RenderingLayers: 1
+  m_ShadowRenderingLayers: 1
+--- !u!1001 &5687450000454426460
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7324245354653260495, guid: 38e9e4d34de066d41941fe05b03f1bb7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7324245354653260495, guid: 38e9e4d34de066d41941fe05b03f1bb7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7324245354653260495, guid: 38e9e4d34de066d41941fe05b03f1bb7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7324245354653260495, guid: 38e9e4d34de066d41941fe05b03f1bb7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7324245354653260495, guid: 38e9e4d34de066d41941fe05b03f1bb7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7324245354653260495, guid: 38e9e4d34de066d41941fe05b03f1bb7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7324245354653260495, guid: 38e9e4d34de066d41941fe05b03f1bb7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7324245354653260495, guid: 38e9e4d34de066d41941fe05b03f1bb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7324245354653260495, guid: 38e9e4d34de066d41941fe05b03f1bb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7324245354653260495, guid: 38e9e4d34de066d41941fe05b03f1bb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8509441460001954737, guid: 38e9e4d34de066d41941fe05b03f1bb7, type: 3}
+      propertyPath: m_Name
+      value: InitObj
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 38e9e4d34de066d41941fe05b03f1bb7, type: 3}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 589917766}
+  - {fileID: 2069096357}
+  - {fileID: 1232688208}
+  - {fileID: 1196835577}
+  - {fileID: 5687450000454426460}

--- a/Assets/Scenes/Initialization.unity
+++ b/Assets/Scenes/Initialization.unity
@@ -130,6 +130,7 @@ GameObject:
   - component: {fileID: 589917766}
   - component: {fileID: 589917765}
   - component: {fileID: 589917764}
+  - component: {fileID: 589917767}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -211,6 +212,50 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &589917767
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 589917763}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.RenderPipelines.Universal.Runtime::UnityEngine.Rendering.Universal.UniversalAdditionalCameraData
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+  m_Version: 2
 --- !u!1 &682120670
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Initialization.unity.meta
+++ b/Assets/Scenes/Initialization.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9a889bfcacefb72448fd3d3e6765e804
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -224,7 +224,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 72
+  m_fontSize: 64.05
   m_fontSizeBase: 14
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -801,50 +801,6 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1144710009
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1144710011}
-  - component: {fileID: 1144710010}
-  m_Layer: 0
-  m_Name: InputManager
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1144710010
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1144710009}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0bc6ec01ad2ca4a49817bbe901f1fde8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::InputManager
---- !u!4 &1144710011
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1144710009}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 350.36108, y: 282.0247, z: -538.4378}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1609,6 +1565,63 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1001 &6705975657174543756
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1167604989491927238, guid: 8a21dbe6c6494134b8490d9a17ae4490, type: 3}
+      propertyPath: m_Name
+      value: InputManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 7072706191849307978, guid: 8a21dbe6c6494134b8490d9a17ae4490, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 350.36108
+      objectReference: {fileID: 0}
+    - target: {fileID: 7072706191849307978, guid: 8a21dbe6c6494134b8490d9a17ae4490, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 282.0247
+      objectReference: {fileID: 0}
+    - target: {fileID: 7072706191849307978, guid: 8a21dbe6c6494134b8490d9a17ae4490, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -538.4378
+      objectReference: {fileID: 0}
+    - target: {fileID: 7072706191849307978, guid: 8a21dbe6c6494134b8490d9a17ae4490, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7072706191849307978, guid: 8a21dbe6c6494134b8490d9a17ae4490, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7072706191849307978, guid: 8a21dbe6c6494134b8490d9a17ae4490, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7072706191849307978, guid: 8a21dbe6c6494134b8490d9a17ae4490, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7072706191849307978, guid: 8a21dbe6c6494134b8490d9a17ae4490, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7072706191849307978, guid: 8a21dbe6c6494134b8490d9a17ae4490, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7072706191849307978, guid: 8a21dbe6c6494134b8490d9a17ae4490, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8a21dbe6c6494134b8490d9a17ae4490, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -1618,4 +1631,4 @@ SceneRoots:
   - {fileID: 2008177565}
   - {fileID: 1071022207}
   - {fileID: 1622032203}
-  - {fileID: 1144710011}
+  - {fileID: 6705975657174543756}

--- a/Assets/Scenes/SceneReferenceSO.cs
+++ b/Assets/Scenes/SceneReferenceSO.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+using UnityEditor;
+
+[CreateAssetMenu(menuName = "ScriptableObject/SceneReferenceSO", fileName = "New SceneReferenceSO")]
+public class SceneReferenceSO : ScriptableObject
+{
+    [SerializeField]
+    SceneAsset sceneAsset;
+
+    [HideInInspector] public string SceneName { get; private set; }
+
+    private void OnValidate()
+    {
+        if (sceneAsset == null)
+        {
+            Debug.LogWarning($"Warning: {this} is not initialized with a scene asset! give it one!");
+            return;
+        }
+
+        //Set the value of the scene name
+        SceneName = sceneAsset.name;
+    }
+}

--- a/Assets/Scenes/SceneReferenceSO.cs.meta
+++ b/Assets/Scenes/SceneReferenceSO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a3de8a15533c148468ed81ef7897f43c

--- a/Assets/Scenes/SceneReferenceSO.meta
+++ b/Assets/Scenes/SceneReferenceSO.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 96461dbdb861004458802d73fe1d3735
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SceneReferenceSO/GameScene.asset
+++ b/Assets/Scenes/SceneReferenceSO/GameScene.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a3de8a15533c148468ed81ef7897f43c, type: 3}
+  m_Name: GameScene
+  m_EditorClassIdentifier: Assembly-CSharp::SceneReferenceSO
+  sceneAsset: {fileID: 102900000, guid: b845dea40a115fb4ca323fd9115f2699, type: 3}
+  scenePath: Assets/Scenes/GameScene.unity
+  buildIndex: 2

--- a/Assets/Scenes/SceneReferenceSO/GameScene.asset.meta
+++ b/Assets/Scenes/SceneReferenceSO/GameScene.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3656f95c594475f478b5c2d62995b6d8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SceneReferenceSO/Initialization.asset
+++ b/Assets/Scenes/SceneReferenceSO/Initialization.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a3de8a15533c148468ed81ef7897f43c, type: 3}
+  m_Name: Initialization
+  m_EditorClassIdentifier: Assembly-CSharp::SceneReferenceSO
+  sceneAsset: {fileID: 102900000, guid: 9a889bfcacefb72448fd3d3e6765e804, type: 3}
+  scenePath: Assets/Scenes/Initialization.unity
+  buildIndex: 0

--- a/Assets/Scenes/SceneReferenceSO/Initialization.asset.meta
+++ b/Assets/Scenes/SceneReferenceSO/Initialization.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ecec8295c9ea5fc459cadf337e1facd0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SceneReferenceSO/Main Menu.asset
+++ b/Assets/Scenes/SceneReferenceSO/Main Menu.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a3de8a15533c148468ed81ef7897f43c, type: 3}
+  m_Name: Main Menu
+  m_EditorClassIdentifier: Assembly-CSharp::SceneReferenceSO
+  sceneAsset: {fileID: 102900000, guid: f8780add6fbcba944bf2d50abda04c59, type: 3}
+  scenePath: Assets/Scenes/MainMenu.unity
+  buildIndex: 1

--- a/Assets/Scenes/SceneReferenceSO/Main Menu.asset.meta
+++ b/Assets/Scenes/SceneReferenceSO/Main Menu.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 58620c56919fc844295f14c916bd89ff
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SceneReferenceSO/Map Generator Testing Scene.asset
+++ b/Assets/Scenes/SceneReferenceSO/Map Generator Testing Scene.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a3de8a15533c148468ed81ef7897f43c, type: 3}
+  m_Name: Map Generator Testing Scene
+  m_EditorClassIdentifier: Assembly-CSharp::SceneReferenceSO
+  sceneAsset: {fileID: 102900000, guid: 6100e7d75b7b16e4784f61ec07cbb23b, type: 3}

--- a/Assets/Scenes/SceneReferenceSO/Map Generator Testing Scene.asset.meta
+++ b/Assets/Scenes/SceneReferenceSO/Map Generator Testing Scene.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 579b7cf9857b731478cb3012249289ad
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SceneReferenceSO/PlayerTestScene.asset
+++ b/Assets/Scenes/SceneReferenceSO/PlayerTestScene.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a3de8a15533c148468ed81ef7897f43c, type: 3}
+  m_Name: PlayerTestScene
+  m_EditorClassIdentifier: Assembly-CSharp::SceneReferenceSO
+  sceneAsset: {fileID: 102900000, guid: e76a5c15a13ca684c86b904a4e8635ee, type: 3}

--- a/Assets/Scenes/SceneReferenceSO/PlayerTestScene.asset.meta
+++ b/Assets/Scenes/SceneReferenceSO/PlayerTestScene.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b5c6188e91c59c540b0717cc7f534855
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SceneReferenceSO/SampleScene.asset
+++ b/Assets/Scenes/SceneReferenceSO/SampleScene.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a3de8a15533c148468ed81ef7897f43c, type: 3}
+  m_Name: SampleScene
+  m_EditorClassIdentifier: Assembly-CSharp::SceneReferenceSO
+  sceneAsset: {fileID: 102900000, guid: 99c9720ab356a0642a771bea13969a05, type: 3}

--- a/Assets/Scenes/SceneReferenceSO/SampleScene.asset.meta
+++ b/Assets/Scenes/SceneReferenceSO/SampleScene.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ccae4967bd88d3f4eb8395ec8a0bb136
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,11 +6,23 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
+    path: Assets/Scenes/Initialization.unity
+    guid: 9a889bfcacefb72448fd3d3e6765e804
+  - enabled: 1
     path: Assets/Scenes/MainMenu.unity
     guid: f8780add6fbcba944bf2d50abda04c59
   - enabled: 1
     path: Assets/Scenes/GameScene.unity
     guid: b845dea40a115fb4ca323fd9115f2699
+  - enabled: 1
+    path: Assets/Scenes/PlayerTestScene.unity
+    guid: e76a5c15a13ca684c86b904a4e8635ee
+  - enabled: 1
+    path: Assets/Scenes/SampleScene.unity
+    guid: 99c9720ab356a0642a771bea13969a05
+  - enabled: 1
+    path: Assets/Map Generation/Map Generator Testing Scene.unity
+    guid: 6100e7d75b7b16e4784f61ec07cbb23b
   m_configObjects:
     com.unity.input.settings.actions: {fileID: -944628639613478452, guid: 052faaac586de48259a63d0c4782560b, type: 3}
   m_UseUCBPForAssetBundles: 0


### PR DESCRIPTION
This pull request adds an initialization scene that allows you to bring all singletons to your active scene without needing to add them, removing all null reference exceptions to the singleton objects. Just be sure to add your singletons to the initObj prefab!

This pull request also adds the long-awaited feature of cursor locking. This also comes with input scheme initialization when loading up a scene, so the correct input scheme will always load when loading a new scene.


Please make sure that there are no merge conflicts with this pull. I have made some changes to a couple of systems, and it would be best to ensure that nothing is broken.